### PR TITLE
feat: add ERC20 funding token support to frontend (team qwerty / unstoppable hackathon )

### DIFF
--- a/src/VaultActions.tsx
+++ b/src/VaultActions.tsx
@@ -238,6 +238,11 @@ const VaultActions: React.FC<{ withdrawalAddress?: string }> = ({
   };
 
   const handleWithdraw = async () => {
+    if (!account.address) {
+      console.error("Wallet not connected");
+      return;
+    }
+
     if (!publicClient) {
       console.error("Public client not available");
       return;
@@ -413,12 +418,15 @@ const VaultActions: React.FC<{ withdrawalAddress?: string }> = ({
               <p className="">Withdraw Funds</p>
               <button
                 onClick={handleWithdraw}
+                disabled={!account.address}
                 className="flex h-[34px] min-w-60 overflow-hidden items-center font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-slate-950 text-white shadow hover:bg-black/90 px-4 py-2 max-w-52 whitespace-pre md:flex group relative w-full justify-center gap-2 rounded-md transition-all duration-300 ease-out  border-2 border-purple-600/70 hover:border-purple-600 mt-3"
               >
                 <span className="absolute right-0 h-32 w-8 translate-x-12 rotate-12 bg-white opacity-20 transition-all duration-1000 ease-out group-hover:-translate-x-40"></span>
 
                 <span className="text-white">
-                  {isSubmitting ? "Processing..." : `Withdraw Funds`}
+                  {account.address
+                    ? `${isSubmitting ? "Processing..." : `Withdraw Funds`}`
+                    : "Connect Wallet"}
                 </span>
               </button>
             </div>

--- a/src/VaultActions.tsx
+++ b/src/VaultActions.tsx
@@ -166,15 +166,9 @@ const VaultActions: React.FC<{ withdrawalAddress?: string }> = ({
     formState: { isSubmitting: isSubmitting2 },
   } = useForm<Inputs>();
   const onSubmitForm2: SubmitHandler<Inputs> = async (data) => {
-    // Guard: Ensure fundingToken has loaded and we have required data
-    if (fundingTokenLoading || !fundingToken) {
-      console.error("Funding token not loaded yet");
-      return;
-    }
-
-    // Guard: For ERC20 tokens, ensure decimals and symbol are loaded
-    if (!isNativeCurrency && (tokenDecimals === undefined || tokenSymbol === undefined)) {
-      console.error("Token data not loaded yet");
+    // Guard: Ensure wallet is connected
+    if (!account.address) {
+      console.error("Wallet not connected");
       return;
     }
 
@@ -393,31 +387,17 @@ const VaultActions: React.FC<{ withdrawalAddress?: string }> = ({
                 type="number"
                 step="any"
                 {...register2("ethAmount", { required: true })}
-                placeholder={
-                  fundingTokenLoading
-                    ? "Loading vault details..."
-                    : nativecurrency
-                      ? `Enter Amount of Tokens to add`
-                      : "Connect Wallet to proceed"
-                }
-                disabled={fundingTokenLoading || !nativecurrency}
+                placeholder="Enter Amount of Tokens to add"
+                disabled={!account.address}
               />
               <button
-                disabled={
-                  fundingTokenLoading ||
-                  !nativecurrency ||
-                  (!isNativeCurrency && (tokenDecimals === undefined || tokenSymbol === undefined))
-                }
+                disabled={!account.address}
                 className="flex h-[34px] min-w-60 overflow-hidden items-center font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-slate-950 text-white shadow hover:bg-black/90 px-4 py-2 max-w-52 whitespace-pre md:flex group relative w-full justify-center gap-2 rounded-md transition-all duration-300 ease-out  border-2 border-purple-600/70 hover:border-purple-600 mt-3"
               >
                 <span className="absolute right-0 h-32 w-8 translate-x-12 rotate-12 bg-white opacity-20 transition-all duration-1000 ease-out group-hover:-translate-x-40"></span>
 
                 <span className="text-white">
-                  {fundingTokenLoading
-                    ? "Loading..."
-                    : isSubmitting2
-                      ? "Processing..."
-                      : `Add PTKs`}
+                  {isSubmitting2 ? "Processing..." : `Add PTKs`}
                 </span>
               </button>
             </form>

--- a/src/abi/erc20abi.json
+++ b/src/abi/erc20abi.json
@@ -1,0 +1,283 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "subtractedValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "decreaseAllowance",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "addedValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "increaseAllowance",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]


### PR DESCRIPTION
pr for the issue:
#8 

1)Create Vault Page:

Added radio buttons to choose between "Native ETH" or "ERC20 Token"

When ERC20 is selected, a new field appears to enter the token address

Form labels update automatically (e.g., "Minimum Token Target" instead of "Minimum ETH Target")

Validates that the ERC20 address is correct before allowing submission

2)Vault Details Page:

Shows the correct token symbol for whatever currency the vault is using

Progress bars display the right currency (cBTC, USDC, or whatever token)

Automatically detects if a vault uses native currency or an ERC20 token

3)Contribution Flow:

For ERC20 tokens: Users first approve the vault to spend their tokens, then contribute

For native cBTC: Works the same as before with direct payments

Button text updates to show which currency you're sending

4)New File:

Added erc20abi.json to interact with any ERC20 token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ERC20 token funding support: create vaults that accept ERC20 tokens with address validation and non-zero-address checks.
  * Vault details and purchase flows show funding token symbol and support ERC20 purchases with approve+buy flow; token decimals are auto-detected and displayed.
  * Form labels, placeholders and buttons adapt to selected currency; UI reflects loading and readiness states.

* **Bug Fixes / UX**
  * Validation errors for invalid token addresses; deadline input enforces required date and stronger submission guards; waits for transaction receipts to improve reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->